### PR TITLE
Fixed EasyDDNS.cpp

### DIFF
--- a/EasyDDNS.cpp
+++ b/EasyDDNS.cpp
@@ -45,7 +45,21 @@ void EasyDDNSClass::update(unsigned long ddns_update_interval){
     unsigned long currentMillis = millis(); // Calculate Elapsed Time & Trigger
     if(currentMillis - previousMillis >= interval) {
         previousMillis = currentMillis;
-
+		
+// ######## GET PUBLIC IP ######## //
+        HTTPClient http;
+        http.begin("http://ipv4bot.whatismyipaddress.com/");
+        int httpCode = http.GET();
+        if(httpCode > 0) {
+          if(httpCode == HTTP_CODE_OK) {
+                new_ip = http.getString();
+              }
+        }else{
+          http.end();
+          return;
+        }
+        http.end();
+		
 // ######## GENERATE UPDATE URL ######## //
         if(ddns_choice == "duckdns"){
           update_url = "http://www.duckdns.org/update?domains="+ddns_d+"&token="+ddns_u+"&ip="+new_ip+"";}
@@ -61,20 +75,6 @@ void EasyDDNSClass::update(unsigned long ddns_update_interval){
           Serial.println("## INPUT CORRECT DDNS SERVICE NAME ##");
           return;
          }
-
-// ######## GET PUBLIC IP ######## //
-        HTTPClient http;
-        http.begin("http://ipv4bot.whatismyipaddress.com/");
-        int httpCode = http.GET();
-        if(httpCode > 0) {
-          if(httpCode == HTTP_CODE_OK) {
-                new_ip = http.getString();
-              }
-        }else{
-          http.end();
-          return;
-        }
-        http.end();
 
 // ######## CHECK & UPDATE ######### //
     if(old_ip != new_ip){


### PR DESCRIPTION
the get public ip block should be before the generate update url block..
This way
1) new_ip gets the new ip next
2) update_url gets the link with the new ip
3) and then we check and update

the way it was before, was
1) update_url gets the link with the OLD new_ip value (so its the old ip)
2) new_ip gets updated (but update_url does not!!!)
3) we check and update (basicly with the old ip!!)